### PR TITLE
Add Paper Sources and Paper Sizes to print options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ By default, _PrintIt.ServiceHost_ is listening on http://localhost:7000. The end
 
 List all available printers on the system.
 
+#### [GET] /printers/paperSources?printerPath=\\\\REMOTE_PC_NAME\\PRINTER-NAME
+
+List all paper sources(trays) on the printer with the UNC-path `\\REMOTE_PC_NAME\PRINTER-NAME`.
+
 #### [POST] /printers/install?printerPath=\\\\REMOTE_PC_NAME\\PRINTER-NAME
 
 Install the network printer with the UNC-path `\\REMOTE_PC_NAME\PRINTER-NAME`. 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ List all available printers on the system.
 
 List all paper sources(trays) on the printer with the UNC-path `\\REMOTE_PC_NAME\PRINTER-NAME`.
 
+#### [GET] /printers/paperSizes?printerPath=\\\\REMOTE_PC_NAME\\PRINTER-NAME
+
+List all paper sizes on the printer with the UNC-path `\\REMOTE_PC_NAME\PRINTER-NAME`.
+
 #### [POST] /printers/install?printerPath=\\\\REMOTE_PC_NAME\\PRINTER-NAME
 
 Install the network printer with the UNC-path `\\REMOTE_PC_NAME\PRINTER-NAME`. 
@@ -36,6 +40,8 @@ PdfFile      | :heavy_check_mark: | The PDF file to print (Content-type: applica
 PrinterPath  | :heavy_check_mark: | The UNC-path of the printer to send the PDF to
 PageRange    |                    | An optional page range string (f.e. "1-5", "1, 3", "1, 4-8", "2-", "-5")
 Copies       |                    | An optional number of copies (defaults to 1)
+PaperSource  |                    | An optional name of the page source. See GET for valid page sources
+PaperSize    |                    | An optional name of the page size. See GET for valid page sizes
 
 ## PDFium
 

--- a/src/PrintIt.Core/PdfPrintService.cs
+++ b/src/PrintIt.Core/PdfPrintService.cs
@@ -51,7 +51,7 @@ namespace PrintIt.Core
 
                 if (!paperSourceSet)
                 {
-                    throw new ArgumentException($"paperSource: {paperSource} was not valid for printerName: {printerName}");
+                    throw new SelectPaperSourceException(paperSource, printerName);
                 }
             }
 
@@ -70,7 +70,7 @@ namespace PrintIt.Core
 
                 if (!paperSizeSet)
                 {
-                    throw new ArgumentException($"paperSize: {paperSize} was not valid for printerName: {printerName}");
+                    throw new SelectPaperSizeException(paperSize, printerName);
                 }
             }
 
@@ -95,5 +95,37 @@ namespace PrintIt.Core
     public interface IPdfPrintService
     {
         void Print(Stream pdfStream, string printerName, string pageRange = null, int numberOfCopies = 1, string paperSource = null, string paperSize = null);
+    }
+
+    public sealed class SelectPaperSizeException : Exception
+    {
+        public SelectPaperSizeException(string paperSize, string printerPath)
+            : base($"PaperSize: {paperSize} was not valid for printerName: {printerPath}")
+        {
+            PrinterPath = printerPath;
+            PaperSize = paperSize;
+        }
+
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Public API")]
+        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Public API")]
+        public string PrinterPath { get; }
+
+        public string PaperSize { get; }
+    }
+
+    public sealed class SelectPaperSourceException : Exception
+    {
+        public SelectPaperSourceException(string paperSource, string printerPath)
+            : base($"PaperSource: {paperSource} was not valid for PrinterName: {printerPath}")
+        {
+            PrinterPath = printerPath;
+            PaperSource = paperSource;
+        }
+
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Public API")]
+        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Public API")]
+        public string PrinterPath { get; }
+
+        public string PaperSource { get; }
     }
 }

--- a/src/PrintIt.Core/PrinterService.cs
+++ b/src/PrintIt.Core/PrinterService.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Printing;
 using System.IO;
@@ -17,6 +19,21 @@ namespace PrintIt.Core
 
         public string[] GetInstalledPrinters()
             => PrinterSettings.InstalledPrinters.Cast<string>().ToArray();
+
+        public string[] GetPrinterPageSources(string printerPath)
+        {
+            var allSourceNames = new List<string>();
+            var settings = new PrinterSettings
+            {
+                PrinterName = printerPath,
+            };
+            foreach (PaperSource paperSource in settings.PaperSources)
+            {
+                allSourceNames.Add(paperSource.SourceName);
+            }
+
+            return allSourceNames.ToArray();
+        }
 
         public void InstallPrinter(string printerPath)
         {
@@ -38,6 +55,8 @@ namespace PrintIt.Core
     public interface IPrinterService
     {
         string[] GetInstalledPrinters();
+
+        string[] GetPrinterPageSources(string printerPath);
 
         void InstallPrinter(string printerPath);
     }

--- a/src/PrintIt.Core/PrinterService.cs
+++ b/src/PrintIt.Core/PrinterService.cs
@@ -20,6 +20,21 @@ namespace PrintIt.Core
         public string[] GetInstalledPrinters()
             => PrinterSettings.InstalledPrinters.Cast<string>().ToArray();
 
+        public string[] GetPrinterPageSizes(string printerPath)
+        {
+            var allSizeNames = new List<string>();
+            var settings = new PrinterSettings
+            {
+                PrinterName = printerPath,
+            };
+            foreach (PaperSize paperSize in settings.PaperSizes)
+            {
+                allSizeNames.Add($"{paperSize.PaperName}, {paperSize.Height}, {paperSize.Width}, {paperSize.Kind}, {paperSize.RawKind}");
+            }
+
+            return allSizeNames.ToArray();
+        }
+
         public string[] GetPrinterPageSources(string printerPath)
         {
             var allSourceNames = new List<string>();
@@ -29,7 +44,7 @@ namespace PrintIt.Core
             };
             foreach (PaperSource paperSource in settings.PaperSources)
             {
-                allSourceNames.Add($"{paperSource.SourceName}, {paperSource.Kind.ToString()}, {paperSource.RawKind}");
+                allSourceNames.Add($"{paperSource.SourceName}, {paperSource.Kind}, {paperSource.RawKind}");
             }
 
             return allSourceNames.ToArray();
@@ -55,6 +70,8 @@ namespace PrintIt.Core
     public interface IPrinterService
     {
         string[] GetInstalledPrinters();
+
+        string[] GetPrinterPageSizes(string printerPath);
 
         string[] GetPrinterPageSources(string printerPath);
 

--- a/src/PrintIt.Core/PrinterService.cs
+++ b/src/PrintIt.Core/PrinterService.cs
@@ -29,7 +29,7 @@ namespace PrintIt.Core
             };
             foreach (PaperSource paperSource in settings.PaperSources)
             {
-                allSourceNames.Add(paperSource.SourceName);
+                allSourceNames.Add($"{paperSource.SourceName}, {paperSource.Kind.ToString()}, {paperSource.RawKind}");
             }
 
             return allSourceNames.ToArray();

--- a/src/PrintIt.ServiceHost/Controllers/PrintController.cs
+++ b/src/PrintIt.ServiceHost/Controllers/PrintController.cs
@@ -26,7 +26,9 @@ namespace PrintIt.ServiceHost.Controllers
             _pdfPrintService.Print(pdfStream,
                 printerName: request.PrinterPath,
                 pageRange: request.PageRange,
-                numberOfCopies: request.Copies ?? 1);
+                numberOfCopies: request.Copies ?? 1,
+                paperSource: request.PaperSource, 
+                paperSize: request.PaperSize);
             return Ok();
         }
     }
@@ -42,5 +44,9 @@ namespace PrintIt.ServiceHost.Controllers
         public string PageRange { get; set; }
 
         public int? Copies { get; set; }
+
+        public string PaperSource { get; set; }
+
+        public string PaperSize { get; set; }
     }
 }

--- a/src/PrintIt.ServiceHost/Controllers/PrinterController.cs
+++ b/src/PrintIt.ServiceHost/Controllers/PrinterController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using PrintIt.Core;
 
 namespace PrintIt.ServiceHost.Controllers
@@ -21,6 +22,15 @@ namespace PrintIt.ServiceHost.Controllers
             string[] installedPrinters = _printerService.GetInstalledPrinters();
             return Ok(installedPrinters);
         }
+
+        [HttpGet]
+        [Route("paperSources")]
+        public IActionResult ListPrinterDetails([FromQuery] string printerPath)
+        {
+            string[] printerSettings = _printerService.GetPrinterPageSources(printerPath);
+            return Ok(printerSettings);
+        }
+
 
         [HttpPost]
         [Route("install")]

--- a/src/PrintIt.ServiceHost/Controllers/PrinterController.cs
+++ b/src/PrintIt.ServiceHost/Controllers/PrinterController.cs
@@ -25,12 +25,19 @@ namespace PrintIt.ServiceHost.Controllers
 
         [HttpGet]
         [Route("paperSources")]
-        public IActionResult ListPrinterDetails([FromQuery] string printerPath)
+        public IActionResult ListPaperSources([FromQuery] string printerPath)
         {
-            string[] printerSettings = _printerService.GetPrinterPageSources(printerPath);
-            return Ok(printerSettings);
+            string[] paperSources = _printerService.GetPrinterPageSources(printerPath);
+            return Ok(paperSources);
         }
 
+        [HttpGet]
+        [Route("paperSizes")]
+        public IActionResult ListPaperSizes([FromQuery] string printerPath)
+        {
+            string[] paperSizes = _printerService.GetPrinterPageSizes(printerPath);
+            return Ok(paperSizes);
+        }
 
         [HttpPost]
         [Route("install")]


### PR DESCRIPTION
This PR adds two GET methods which return the Paper Sources(trays) and Paper Sizes for a given printer. 

It also add optional parameters to the print POST to set these properties